### PR TITLE
squid:S1319 - Declarations should use Java collection interfaces such…

### DIFF
--- a/app/src/main/java/com/smedic/tubtub/BackgroundAudioService.java
+++ b/app/src/main/java/com/smedic/tubtub/BackgroundAudioService.java
@@ -42,6 +42,7 @@ import com.squareup.picasso.Target;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.ListIterator;
 
 import at.huber.youtubeExtractor.YouTubeUriExtractor;
@@ -75,7 +76,7 @@ public class BackgroundAudioService extends Service implements MediaPlayer.OnCom
 
     private boolean isStarting = false;
 
-    private ArrayList<YouTubeVideo> youTubeVideos;
+    private List<YouTubeVideo> youTubeVideos;
     private ListIterator<YouTubeVideo> iterator;
 
     private NotificationCompat.Builder builder = null;

--- a/app/src/main/java/com/smedic/tubtub/MainActivity.java
+++ b/app/src/main/java/com/smedic/tubtub/MainActivity.java
@@ -262,7 +262,7 @@ public class MainActivity extends AppCompatActivity {
 
                         new JsonAsyncTask(new JsonAsyncTask.AsyncResponse() {
                             @Override
-                            public void processFinish(ArrayList<String> result) {
+                            public void processFinish(List<String> result) {
                                 suggestions.clear();
                                 suggestions.addAll(result);
                                 String[] columns = {

--- a/app/src/main/java/com/smedic/tubtub/database/YouTubeSqlDb.java
+++ b/app/src/main/java/com/smedic/tubtub/database/YouTubeSqlDb.java
@@ -27,6 +27,7 @@ import com.smedic.tubtub.YouTubePlaylist;
 import com.smedic.tubtub.YouTubeVideo;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * SQLite database for storing recentlyWatchedVideos and playlist
@@ -164,13 +165,13 @@ public class YouTubeSqlDb {
          *
          * @return
          */
-        public ArrayList<YouTubeVideo> readAll() {
+        public List<YouTubeVideo> readAll() {
 
             final String SELECT_QUERY_ORDER_DESC = "SELECT * FROM " + tableName + " ORDER BY "
                     + YouTubeVideoEntry.COLUMN_ENTRY_ID + " DESC";
 
             SQLiteDatabase db = dbHelper.getReadableDatabase();
-            ArrayList<YouTubeVideo> list = new ArrayList<>();
+            List<YouTubeVideo> list = new ArrayList<>();
 
             Cursor c = db.rawQuery(SELECT_QUERY_ORDER_DESC, null);
             while (c.moveToNext()) {
@@ -241,9 +242,9 @@ public class YouTubeSqlDb {
          *
          * @return
          */
-        public ArrayList<YouTubePlaylist> readAll() {
+        public List<YouTubePlaylist> readAll() {
 
-            ArrayList<YouTubePlaylist> list = new ArrayList<>();
+            List<YouTubePlaylist> list = new ArrayList<>();
             SQLiteDatabase db = dbHelper.getReadableDatabase();
 
             Cursor c = db.rawQuery(YouTubePlaylistEntry.SELECT_QUERY_ORDER_DESC, null);

--- a/app/src/main/java/com/smedic/tubtub/fragments/PlaylistsFragment.java
+++ b/app/src/main/java/com/smedic/tubtub/fragments/PlaylistsFragment.java
@@ -50,6 +50,7 @@ import com.smedic.tubtub.utils.NetworkConf;
 import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class that handles list of the playlists acquired from YouTube
@@ -59,7 +60,7 @@ public class PlaylistsFragment extends Fragment implements YouTubeVideosReceiver
 
     private static final String TAG = "SMEDIC PlaylistsFrag";
 
-    private ArrayList<YouTubePlaylist> playlists;
+    private List<YouTubePlaylist> playlists;
     private DynamicListView playlistsListView;
     private Handler handler;
     private PlaylistAdapter playlistsAdapter;
@@ -272,7 +273,7 @@ public class PlaylistsFragment extends Fragment implements YouTubeVideosReceiver
      * @param youTubeVideos - list to be played in background service
      */
     @Override
-    public void onVideosReceived(ArrayList<YouTubeVideo> youTubeVideos) {
+    public void onVideosReceived(List<YouTubeVideo> youTubeVideos) {
         //if playlist is empty, do not start service
         if (youTubeVideos.isEmpty()) {
             getActivity().runOnUiThread(new Runnable() {
@@ -323,7 +324,7 @@ public class PlaylistsFragment extends Fragment implements YouTubeVideosReceiver
      * @param youTubePlaylists - list of playlists to be shown in list view
      */
     @Override
-    public void onPlaylistsReceived(ArrayList<YouTubePlaylist> youTubePlaylists) {
+    public void onPlaylistsReceived(List<YouTubePlaylist> youTubePlaylists) {
 
         //refresh playlists in database
         YouTubeSqlDb.getInstance().playlists().deleteAll();

--- a/app/src/main/java/com/smedic/tubtub/fragments/SearchFragment.java
+++ b/app/src/main/java/com/smedic/tubtub/fragments/SearchFragment.java
@@ -40,6 +40,7 @@ import com.smedic.tubtub.utils.Config;
 import com.smedic.tubtub.utils.NetworkConf;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class that handles list of the videos searched on YouTube
@@ -50,8 +51,8 @@ public class SearchFragment extends ListFragment implements YouTubeVideosReceive
     private static final String TAG = "SMEDIC search frag";
     private DynamicListView videosFoundListView;
     private Handler handler;
-    private ArrayList<YouTubeVideo> searchResultsList;
-    private ArrayList<YouTubeVideo> scrollResultsList;
+    private List<YouTubeVideo> searchResultsList;
+    private List<YouTubeVideo> scrollResultsList;
     private VideosAdapter videoListAdapter;
     private YouTubeSearch youTubeSearch;
     private ProgressBar loadingProgressBar;
@@ -196,7 +197,7 @@ public class SearchFragment extends ListFragment implements YouTubeVideosReceive
      * @param youTubeVideos - videos to be shown in list view
      */
     @Override
-    public void onVideosReceived(ArrayList<YouTubeVideo> youTubeVideos) {
+    public void onVideosReceived(List<YouTubeVideo> youTubeVideos) {
         searchResultsList.clear();
         scrollResultsList.clear();
         scrollResultsList.addAll(youTubeVideos);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1319

Please let me know if you have any questions.

M-Ezzat
